### PR TITLE
removeCol doesn't work when it's an empty grid

### DIFF
--- a/gridmaker/src/App.js
+++ b/gridmaker/src/App.js
@@ -48,7 +48,7 @@ function App()
 
   const handleRemoveCol = () => 
   {
-    if (tableData[0].length > 1) //are there more than one column in the table rn? if yes then enter, why the [0]
+    if (tableData.length > 1) //are there more than one column in the table rn? if yes then enter, why the [0]? its no longer needed, it was causing the error but now it checks the whole array
     {
       const newTableData = tableData.map(row => [...row.slice(0, -1)]); //new table data same expl as the rest, .map iterates thru the rows, spread operator with the slice creates new row with the last cell removed aka removes a column
       setTableData(newTableData); //update

--- a/gridmaker/src/App.js
+++ b/gridmaker/src/App.js
@@ -48,7 +48,7 @@ function App()
 
   const handleRemoveCol = () => 
   {
-    if (tableData[0].length > 1) //are there more than one column in the table rn? if yes then enter
+    if (tableData[0].length > 1) //are there more than one column in the table rn? if yes then enter, why the [0]
     {
       const newTableData = tableData.map(row => [...row.slice(0, -1)]); //new table data same expl as the rest, .map iterates thru the rows, spread operator with the slice creates new row with the last cell removed aka removes a column
       setTableData(newTableData); //update


### PR DESCRIPTION
When there is an empty grid, clicking removeRow and removeCol shouldn't do anything. However, we run into an error when we click removeCol without any columns present:

https://github.com/Rahatk1/ReactGRIDMAKER/assets/90419249/44ada61e-da66-4175-b9ce-4d8180394f16